### PR TITLE
Remove MSD Calculation and add CoM velocity removal

### DIFF
--- a/src/fix_hmc.cpp
+++ b/src/fix_hmc.cpp
@@ -684,17 +684,17 @@ double FixHMC::compute_vector(int item)
     return DeltaKE;
   else if (n == 4)
     return DeltaPE + DeltaKE;
-  else if (n == 5) {
-    double *dx, local_msd = 0.0;
-    int nlocal = atom->nlocal;
-    for (int i = 0; i < nlocal; i++) {
-      dx = deltax[i];
-      local_msd += dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2];
-    }
-    double msd;
-    MPI_Allreduce(&local_msd,&msd,1,MPI_DOUBLE,MPI_SUM,world);
-    msd /= atom->natoms;
-    return msd;
+  // else if (n == 5) {
+  //   double *dx, local_msd = 0.0;
+  //   int nlocal = atom->nlocal;
+  //   for (int i = 0; i < nlocal; i++) {
+  //     dx = deltax[i];
+  //     local_msd += dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2];
+  //   }
+  //   double msd;
+  //   MPI_Allreduce(&local_msd,&msd,1,MPI_DOUBLE,MPI_SUM,world);
+  //   msd /= atom->natoms;
+  //   return msd;
   }
   else
     return 0.0;
@@ -868,6 +868,9 @@ void FixHMC::random_velocities()
       v[i][0] = stdev*random->gaussian();
       v[i][1] = stdev*random->gaussian();
       v[i][2] = stdev*random->gaussian();
+  
+// add a velocity rescaling algorithm here to ensure that the velocity of the center of mass of the system is zero. 
+//This prevents the potential flying icecube problem.
     }
 }
 


### PR DESCRIPTION
**Summary**

From what I see, the mean-squared displacement is calculated but is not used for any processes related to HMC. So, removing it will speed up the code.

Also, the velocities can be rescaled to ensure that the target temperature is achieved when the velocities are re-initialized. 

**Related Issue(s)**

None

**Author(s)**

Baris Eser Ugur

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Shouldn't affect anything unless newer versions need the calculation of mean-squared displacement.


- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


